### PR TITLE
feat: matching_expr option for destination

### DIFF
--- a/lib/redis_counters/dumpers/destination.rb
+++ b/lib/redis_counters/dumpers/destination.rb
@@ -64,6 +64,18 @@ module RedisCounters
       # Условия соединяются через AND.
       attr_accessor :source_conditions
 
+      # Public: Опциональное выражение для определения одинаковых записей в исходной (source) и целевой (target)
+      # таблицах. Эту опцию имеет смысл использовать если например нужно добавить функцию на какую-нибудь колонку,
+      # например:
+      #
+      # matching_expr <<-SQL
+      #   (source.company_id, source.date, coalesce(source.referer, '')) =
+      #     (target.company_id, target.date, coalesce(target.referer, ''))
+      # SQL
+      #
+      # Returns String
+      attr_accessor :matching_expr
+
       def initialize(engine)
         @engine = engine
         @fields_map = HashWithIndifferentAccess.new
@@ -166,6 +178,10 @@ module RedisCounters
       end
 
       def matching_expression
+        matching_expr || default_matching_expr
+      end
+
+      def default_matching_expr
         source_key_fields = key_fields.map { |field| "source.#{field}" }.join(', ')
         target_key_fields = key_fields.map { |field| "target.#{field}" }.join(', ')
         "(#{source_key_fields}) = (#{target_key_fields})"

--- a/lib/redis_counters/dumpers/dsl/destination.rb
+++ b/lib/redis_counters/dumpers/dsl/destination.rb
@@ -12,6 +12,7 @@ module RedisCounters
           alias_method :destination, :target
 
           setter :model
+          setter :matching_expr
 
           varags_setter :fields
           varags_setter :key_fields

--- a/spec/internal/app/models/nullable_stat.rb
+++ b/spec/internal/app/models/nullable_stat.rb
@@ -1,0 +1,2 @@
+class NullableStat < ActiveRecord::Base
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -46,4 +46,10 @@ ActiveRecord::Schema.define do
   end
 
   add_index :stats_agg_totals, [:record_id], unique: true
+
+  create_table :nullable_stats do |t|
+    t.date :date, null: false
+    t.integer :value, null: false, default: 0
+    t.string :payload
+  end
 end


### PR DESCRIPTION
https://jira.railsc.ru/browse/CK-862 - пункт 4.

Аргумент для этой опции получается слишком длинный - более 150 символов в строке :(.