### PR TITLE
Remove hstore dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activerecord-postgres-hstore', require: false
+gem 'simple_hstore_accessor', '~> 0.2', require: false
+
 gemspec

--- a/dip.yml
+++ b/dip.yml
@@ -42,5 +42,6 @@ interaction:
 provision:
   - docker volume create --name bundler_data
   - dip bundle config --local https://gems.railsc.ru/ ${APRESS_GEMS_CREDENTIALS}
-  - dip bundle install --full-index
+  - dip clean
+  - dip bundle install
   - dip appraisal install

--- a/lib/redis_counters/dumpers/version.rb
+++ b/lib/redis_counters/dumpers/version.rb
@@ -1,5 +1,5 @@
 module RedisCounters
   module Dumpers
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/redis_counters-dumpers.gemspec
+++ b/redis_counters-dumpers.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'redis-namespace', '>= 1.3'
   spec.add_runtime_dependency 'callbacks_rb', '>= 0.0.1'
   spec.add_runtime_dependency 'redis_counters', '>= 1.3'
-  spec.add_runtime_dependency 'activerecord-postgres-hstore'
-  spec.add_runtime_dependency 'simple_hstore_accessor', '~> 0.2'
 
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '>= 10.0'

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define do
     t.hstore :params
   end
 
-  add_index :stats_by_days, [:record_id, :column_id, :date], unique: true
+  add_index :stats_by_days, [:record_id, :column_id, :date, :params], unique: true, name: :uq
 
   create_table :stats_totals do |t|
     t.integer :record_id, null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define do
     t.hstore :params
   end
 
-  add_index :stats_totals, [:record_id, :column_id], unique: true
+  add_index :stats_totals, [:record_id, :column_id, :params], unique: true
 
   create_table :stats_agg_totals do |t|
     t.integer :record_id, null: false

--- a/spec/lib/redis_counters/dumpers/engine_spec.rb
+++ b/spec/lib/redis_counters/dumpers/engine_spec.rb
@@ -26,6 +26,7 @@ describe RedisCounters::Dumpers::Engine do
         key_fields :record_id, :column_id, :params
         increment_fields :hits
         map :hits, to: :value
+        map :params, to: "COALESCE(params, '')"
       end
 
       destination do


### PR DESCRIPTION
Нужно для 4 рельсов.

Тесты исправлены тк они не проходят на редис_каунтерс 1.5, из-за того что там брекинг-ченч, раньше если на вход подать пустую строку, на выходе была пустая строка, щас нил.